### PR TITLE
[Feat] business exception 및 ApiResponse 추가

### DIFF
--- a/src/main/java/com/sparta/petnexus/common/exception/BusinessException.java
+++ b/src/main/java/com/sparta/petnexus/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.sparta.petnexus.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sparta/petnexus/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/petnexus/common/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.sparta.petnexus.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // user
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U001", "존재하지 않는 사용자입니다."),
+    EXISTED_EMAIL(HttpStatus.CONFLICT, "U002", "중복된 이메일 입니다."),
+    BAD_ID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "아이디나 비밀번호가 맞지 않습니다."),
+    PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "U004", "비밀번호가 일치하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/petnexus/common/exception/ErrorResponseDto.java
+++ b/src/main/java/com/sparta/petnexus/common/exception/ErrorResponseDto.java
@@ -1,0 +1,47 @@
+package com.sparta.petnexus.common.exception;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+@Getter
+@Builder
+public class ErrorResponseDto {
+
+    private String errorCode;
+    private String errorMessage;
+
+    public static ErrorResponseDto of(String errorCode, String errorMessage) {
+        return ErrorResponseDto.builder()
+                .errorCode(errorCode)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    public static ErrorResponseDto of(String errorCode, BindingResult bindingResult) {
+        return ErrorResponseDto.builder()
+                .errorCode(errorCode)
+                .errorMessage(createErrorMessage(bindingResult))
+                .build();
+    }
+
+    private static String createErrorMessage(BindingResult bindingResult) {
+        StringBuilder sb = new StringBuilder();
+        boolean isFirst = true;
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        for (FieldError fieldError : fieldErrors) {
+            if (!isFirst) {
+                sb.append(", ");
+            } else {
+                isFirst = false;
+            }
+            sb.append("[");
+            sb.append(fieldError.getField());
+            sb.append("] ");
+            sb.append(fieldError.getDefaultMessage());
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/sparta/petnexus/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/petnexus/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.sparta.petnexus.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 로직 실행 중 에러 발생하는 경우
+    @ExceptionHandler(value = BusinessException.class)
+    protected ResponseEntity<ErrorResponseDto> handleBusinessException(BusinessException e) {
+        log.error("BusinessException", e);
+        ErrorResponseDto errorResponse = ErrorResponseDto.of(e.getErrorCode().getCode(),
+                e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+}

--- a/src/main/java/com/sparta/petnexus/common/response/ApiResponse.java
+++ b/src/main/java/com/sparta/petnexus/common/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.sparta.petnexus.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse {
+
+    private String message;
+    private Integer statusCode;
+
+    public ApiResponse(String massage, Integer statusCode) {
+        this.message = massage;
+        this.statusCode = statusCode;
+    }
+}


### PR DESCRIPTION
## 요약

* 커스텀 exception을 통한 error code 관리
* ApiResponse를 통한 response 메세지 및 코드 응답

## 구현상세

1. `GlobalExceptionHandler`에 커스텀 하여 사용할 `BusinessException` 추가
exception 발생 시, `ErrorCode` 에 에러 코드 및 메세지를 추가하여 사용할 수 있습니다.

2. `ApiResponse` 를 통한 응답 
`ResponsEntity` body부분에 구현한 `ApiResponse`를 추가하여 메세지 및 코드 응답을 확인 할 수 있습니다.


