### PR TITLE
[Feat] 유저 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/sparta/petnexus/PetNexusApplication.java
+++ b/src/main/java/com/sparta/petnexus/PetNexusApplication.java
@@ -2,8 +2,9 @@ package com.sparta.petnexus;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class PetNexusApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sparta/petnexus/common/config/PasswordEncode.java
+++ b/src/main/java/com/sparta/petnexus/common/config/PasswordEncode.java
@@ -1,0 +1,14 @@
+package com.sparta.petnexus.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncode {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sparta/petnexus/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/petnexus/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.sparta.petnexus.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,5 +18,15 @@ public class GlobalExceptionHandler {
         ErrorResponseDto errorResponse = ErrorResponseDto.of(e.getErrorCode().getCode(),
                 e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+
+    // 회원가입 valid 에러 발생하는 경우
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponseDto> handleValidationException(
+            MethodArgumentNotValidException e) {
+        log.error("ValidationException", e);
+        ErrorResponseDto errorResponse = ErrorResponseDto.of(HttpStatus.BAD_REQUEST.toString(),
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 }

--- a/src/main/java/com/sparta/petnexus/user/controller/UserController.java
+++ b/src/main/java/com/sparta/petnexus/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.sparta.petnexus.user.controller;
+
+import com.sparta.petnexus.common.response.ApiResponse;
+import com.sparta.petnexus.user.dto.SignUpUserRequest;
+import com.sparta.petnexus.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/user/signup")
+    public ResponseEntity<ApiResponse> signUp(@RequestBody @Valid SignUpUserRequest request) {
+        userService.signUp(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse("회원가입 완료", HttpStatus.CREATED.value()));
+    }
+}

--- a/src/main/java/com/sparta/petnexus/user/dto/SignUpUserRequest.java
+++ b/src/main/java/com/sparta/petnexus/user/dto/SignUpUserRequest.java
@@ -1,0 +1,40 @@
+package com.sparta.petnexus.user.dto;
+
+import com.sparta.petnexus.user.entity.User;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignUpUserRequest {
+
+    @NotNull(message = "email 필수 입니다.")
+    @Pattern(regexp = "[a-zA-z0-9]+@[a-zA-z]+[.]+[a-zA-z.]+", message = "email 형식이 맞지 않습니다.")
+    private String email;
+
+    @NotNull(message = "password 필수 입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]*$", message = "알파벳 대소문자(a~z, A~Z), 숫자(0~9)만 입력 가능합니다.")
+    @Size(min = 7, max = 16)
+    private String password;
+
+    private String username;
+
+    // username 미작성시, 임의 "user"로 저장
+    private String usernameNotNull(String username){
+        if(username==null){
+            username = "user";
+        }
+        return username;
+    }
+
+    public User toEntity(String encodePassword) {
+        return User.builder()
+                .email(this.email)
+                .password(encodePassword)
+                .username(usernameNotNull(this.username))
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/petnexus/user/entity/User.java
+++ b/src/main/java/com/sparta/petnexus/user/entity/User.java
@@ -1,0 +1,27 @@
+package com.sparta.petnexus.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    private String email;
+    private String password;
+    private String username;
+}

--- a/src/main/java/com/sparta/petnexus/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/petnexus/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.petnexus.user.repository;
+
+import com.sparta.petnexus.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/sparta/petnexus/user/service/UserService.java
+++ b/src/main/java/com/sparta/petnexus/user/service/UserService.java
@@ -1,0 +1,27 @@
+package com.sparta.petnexus.user.service;
+
+import com.sparta.petnexus.common.exception.BusinessException;
+import com.sparta.petnexus.common.exception.ErrorCode;
+import com.sparta.petnexus.user.dto.SignUpUserRequest;
+import com.sparta.petnexus.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public void signUp(SignUpUserRequest request) {
+
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(ErrorCode.EXISTED_EMAIL);
+        }
+
+        String encodePassword = passwordEncoder.encode(request.getPassword());
+        userRepository.save(request.toEntity(encodePassword));
+    }
+}


### PR DESCRIPTION
## 구현된 API
### POST /api/user/signup
- 회원가입 구현
- validation 예외처리

## API 명세
- api/user→ api/user/signup 수정

## 제안
- CRUD구현시, Read를 제외 나머지는 ApiResponse으로 메세지와 상태코드만 전달하면 좋을 것 같습니다.