### PR TITLE
[Feat] RefreshToken 구현 DB저장 방식

### DIFF
--- a/src/main/java/com/sparta/petnexus/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/petnexus/common/exception/ErrorCode.java
@@ -7,17 +7,19 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // user
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U001", "존재하지 않는 사용자입니다."),
+    NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "U001", "존재하지 않는 사용자입니다."),
     EXISTED_EMAIL(HttpStatus.CONFLICT, "U002", "중복된 이메일 입니다."),
     BAD_ID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "아이디나 비밀번호가 맞지 않습니다."),
-    PASSWORD_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "U004", "비밀번호가 일치하지 않습니다."),
+    DO_NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "U004", "비밀번호가 일치하지 않습니다."),
     //post
     NOT_FOUND_POST(HttpStatus.BAD_REQUEST,"P001","존재하지 않는 post 입니다."),
     NOT_POST_UPDATE(HttpStatus.BAD_REQUEST,"P002","작셩자만 수정할 수 있습니다."),
-    NOT_POST_DELETE(HttpStatus.BAD_REQUEST,"P003","작셩자만 삭제할 수 있습니다.")
+    NOT_POST_DELETE(HttpStatus.BAD_REQUEST,"P003","작셩자만 삭제할 수 있습니다."),
     // trade
-    NOT_FOUND_TRADE(HttpStatus.BAD_REQUEST, "U001", "존재하지 않는 거래 게시글입니다.")
-
+    NOT_FOUND_TRADE(HttpStatus.BAD_REQUEST, "T001", "존재하지 않는 거래 게시글입니다."),
+    //Token
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"TK001","잘못된 리프레쉬 토큰입니다. 재로그인 해주세요."),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"TK002","리프레쉬 토큰을 찾을 수 없습니다. 재로그인 해주세요.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sparta/petnexus/common/security/entity/UserDetailServiceImp.java
+++ b/src/main/java/com/sparta/petnexus/common/security/entity/UserDetailServiceImp.java
@@ -21,7 +21,7 @@ public class UserDetailServiceImp implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email);
         if (user == null) {
-            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+            throw new BusinessException(ErrorCode.NOT_FOUND_USER);
         }
         return new UserDetailsImpl(user);
 

--- a/src/main/java/com/sparta/petnexus/common/security/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/sparta/petnexus/common/security/filter/TokenAuthenticationFilter.java
@@ -24,7 +24,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain) throws ServletException, IOException {
 
         String authorizationHeader = request.getHeader(TokenProvider.HEADER_AUTHORIZATION);
-        String token = getAccessToken(authorizationHeader);
+        String token = tokenProvider.getAccessToken(authorizationHeader);
 
         if (tokenProvider.validToken(token)) {
             Authentication authentication = tokenProvider.getAuthentication(token);
@@ -32,14 +32,5 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String getAccessToken(String authorizationHeader) {
-        if (authorizationHeader != null && authorizationHeader.startsWith(
-                TokenProvider.BEARER_PREFIX)) {
-            return authorizationHeader.substring(TokenProvider.BEARER_PREFIX.length());
-        }
-
-        return null;
     }
 }

--- a/src/main/java/com/sparta/petnexus/common/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sparta/petnexus/common/security/jwt/TokenProvider.java
@@ -22,7 +22,10 @@ public class TokenProvider {
     private final UserDetailServiceImp userDetailServiceImp;
 
     public static final String HEADER_AUTHORIZATION = "Authorization";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
     public static final String BEARER_PREFIX = "Bearer ";
+    public static final Duration ACCESS_TOKEN_DURATION = Duration.ofHours(2);
+    public static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(7);
 
     public String generateToken(User user, Duration expiredAt) {
         Date now = new Date();
@@ -66,6 +69,15 @@ public class TokenProvider {
                 .setSigningKey(jwtProperties.getSecretKey())
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(
+                TokenProvider.BEARER_PREFIX)) {
+            return authorizationHeader.substring(TokenProvider.BEARER_PREFIX.length());
+        }
+
+        return null;
     }
 
 }

--- a/src/main/java/com/sparta/petnexus/token/controller/TokenController.java
+++ b/src/main/java/com/sparta/petnexus/token/controller/TokenController.java
@@ -1,0 +1,31 @@
+package com.sparta.petnexus.token.controller;
+
+import com.sparta.petnexus.common.response.ApiResponse;
+import com.sparta.petnexus.common.security.jwt.TokenProvider;
+import com.sparta.petnexus.token.service.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @PostMapping("/api/token")
+    public ResponseEntity<ApiResponse> createNewAccessToken(
+            HttpServletRequest request, HttpServletResponse httpResponse) {
+
+        String newAccessToken = tokenService.createNewAccessToken(request);
+
+        httpResponse.addHeader(TokenProvider.HEADER_AUTHORIZATION, newAccessToken);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse("AccessToken 재발행 완료", HttpStatus.CREATED.value()));
+    }
+
+}

--- a/src/main/java/com/sparta/petnexus/token/entity/RefreshToken.java
+++ b/src/main/java/com/sparta/petnexus/token/entity/RefreshToken.java
@@ -1,0 +1,37 @@
+package com.sparta.petnexus.token.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+
+    public RefreshToken update(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+
+        return this;
+    }
+}

--- a/src/main/java/com/sparta/petnexus/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/petnexus/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.petnexus.token.repository;
+
+
+import com.sparta.petnexus.token.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/sparta/petnexus/token/service/TokenService.java
+++ b/src/main/java/com/sparta/petnexus/token/service/TokenService.java
@@ -1,0 +1,39 @@
+package com.sparta.petnexus.token.service;
+
+
+import com.sparta.petnexus.common.exception.BusinessException;
+import com.sparta.petnexus.common.exception.ErrorCode;
+import com.sparta.petnexus.common.security.jwt.TokenProvider;
+import com.sparta.petnexus.token.entity.RefreshToken;
+import com.sparta.petnexus.token.repository.RefreshTokenRepository;
+import com.sparta.petnexus.user.entity.User;
+import com.sparta.petnexus.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenProvider tokenProvider;
+    private final UserService userService;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createNewAccessToken(HttpServletRequest request) {
+
+        String authorizationHeader = request.getHeader(TokenProvider.REFRESH_TOKEN_COOKIE_NAME);
+        String refreshToken = tokenProvider.getAccessToken(authorizationHeader);
+
+        if (!tokenProvider.validToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        RefreshToken token = refreshTokenRepository.findByRefreshToken(authorizationHeader)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_REFRESH_TOKEN));
+
+        User user = userService.findById(token.getId());
+
+        return tokenProvider.generateToken(user, TokenProvider.ACCESS_TOKEN_DURATION);
+    }
+}


### PR DESCRIPTION
## 요약
- jwt access token 만료시, refresh token 을 이용해 재 발급이 가능합니다.
- DB저장 방식입니다.

## 구현된 API
### POST /api/token
-유저가 로그인시 htttp Header에 access token, refresh token을 발행합니다.

![image](https://github.com/JihyeChu/PetNexus/assets/132051431/c76720ee-cfee-4b3a-a032-8a577c9b73a3)

-저장 된 refresh token을 통해 access token을 발행 할 수 있습니다.

![image](https://github.com/JihyeChu/PetNexus/assets/132051431/85b0a95d-ac60-4ea1-86e3-95791de0d938)



