### PR TITLE
[Feat] Swagger 추가(JWT 인증 버튼 셋업)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     // STOMP
     implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.3-1'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/petnexus/chat/controller/ChatController.java
+++ b/src/main/java/com/sparta/petnexus/chat/controller/ChatController.java
@@ -4,20 +4,25 @@ import com.sparta.petnexus.chat.dto.ChatListResponseDto;
 import com.sparta.petnexus.chat.dto.ChatRequestDto;
 import com.sparta.petnexus.chat.dto.ChatResponseDto;
 import com.sparta.petnexus.chat.service.ChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Log4j2
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "채팅 관련 API", description = "채팅 관련 API 입니다.")
 public class ChatController {
     private final SimpMessagingTemplate template; //특정 Broker 로 메세지를 전달
     private final ChatService chatService;
@@ -37,9 +42,10 @@ public class ChatController {
         template.convertAndSend("/sub/chat/" + savedMessage.getRoomId(), savedMessage);
     }
 
-    // 채팅방 채팅 목록 조회
     @GetMapping("/chat/{roomId}")
-    public ResponseEntity<ChatListResponseDto> getAllChatByGroupId(@PathVariable Long roomId) {
+    @Operation(summary = "채팅방 채팅 목록 조회", description = "@PathVariable을 통해 roomId를 받아와, 해당 채팅방에 존재하는 채팅 목록을 조회합니다.")
+    public ResponseEntity<ChatListResponseDto> getAllChatByGroupId(
+        @Parameter(name = "roomId", description = "특정 채팅방 id", in = ParameterIn.PATH) @PathVariable Long roomId) {
         ChatListResponseDto result = chatService.getAllChatByRoomId(roomId);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/sparta/petnexus/chat/dto/ChatResponseDto.java
+++ b/src/main/java/com/sparta/petnexus/chat/dto/ChatResponseDto.java
@@ -1,17 +1,24 @@
 package com.sparta.petnexus.chat.dto;
 
 import com.sparta.petnexus.chat.entity.Chat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
+@Schema(description = "채팅방 조회 응답 DTO")
 public class ChatResponseDto {
+    @Schema(description = "채팅방 아이디", example = "1")
     private Long roomId;
+    @Schema(description = "작성자 아이디", example = "1")
     private Long userId;
+    @Schema(description = "작성자")
     private String writer;
+    @Schema(description = "메세지 내용")
     private String message;
+    @Schema(description = "메세지 생성 일자")
     private LocalDateTime createdAt;
 
     public static ChatResponseDto of(Chat chat) {

--- a/src/main/java/com/sparta/petnexus/common/security/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/petnexus/common/security/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.sparta.petnexus.common.security.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+            .version("v1.0.0")
+            .title("API")
+            .description("");
+
+        // SecurityScheme 명
+        String jwt = "JWT";
+        // API 요청헤더에 인증정보(토큰) 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        // SecuritySchemes 등록
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+            .name(jwt)
+            .type(SecurityScheme.Type.HTTP) // HTTP 방식
+            .scheme("bearer")
+            .bearerFormat("JWT") // 토큰 형식을 지정하는 임의의 문자(Optional)
+        );
+
+        return new OpenAPI()
+            .info(info)
+            .addSecurityItem(securityRequirement)
+            .components(components);
+    }
+
+}

--- a/src/main/java/com/sparta/petnexus/common/security/config/securityConfig.java
+++ b/src/main/java/com/sparta/petnexus/common/security/config/securityConfig.java
@@ -44,6 +44,7 @@ public class securityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                         .permitAll()
                         .requestMatchers("/api/user/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll() // swagger
                         .anyRequest().permitAll());
         return http.build();
     }


### PR DESCRIPTION
# Springdoc-openapi(swagger) 설정
spring 프로젝트에 swagger 적용하기!
spring에 많이 사용되는 swagger llibrary는 
[[springfox](https://github.com/springfox/springfox)]와 
[[springdoc](https://github.com/springdoc/springdoc-openapi)]가 있다. 
최근에는 `springdoc`을 많이 사용한다고 한다.

우리가 일상적으로 사용하는 평범한 controller 코드에 몇 가지 어노테이션을 추가해주면, Swagger가 어노테이션을 이용해 API 정보를 읽는다.
그리고 읽어온 데이터를 이용해 이렇게 웹 UI를 통해 API 문서를 자동으로 제공해준다.

# 1. build.gradle 설정
```
// swagger
 implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
```

# 2. securityConfig
```
.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll() // swagger
```

# 3. Controller 설정
## **`@Tag`  Controller에 전체에 Tag 추가**
```
@Tag(name = "채팅 관련 API", description = "채팅 관련 API 입니다.")
public class ChatController {
```
![5FD184D6-7411-46BA-A346-CD9AB02EFED3_4_5005_c](https://github.com/JihyeChu/PetNexus/assets/126750615/1fbcacf8-b8a9-4be1-bffd-b2de80b224e9)
이렇게 API들이 Swagger UI에서 Tag 단위로 그룹핑된다. 가독성을 높여주는 설정이다.     
<br/>

## **`@Operation` 각 Controller에 API 메타 데이터 정보 명세**
@Operation를 이용해 해당 API가 어떤 리소스를 나타내는지 간략한 설명을 추가할 수 있다.
- summary: api에 대한 간략한 설명
- description: api에 대한 상세 설명
```
@GetMapping("/chat/{roomId}")
@Operation(summary = "채팅방 채팅 목록 조회", description = "@PathVariable을 통해 roomId를 받아와 해당 채팅방에 존재하는 채팅 목록을 조회합니다.")
    public ResponseEntity<ChatListResponseDto> getAllChatByGroupId(
```

## **`@Parameter`path, cookie, query, header 등등 요청과 함께 들어오는 파라미터**
- name : 이름
- description : 상세 설명
- in : parameter로 들어올 타입
- example : 예시
- required : 해당 값 필수 여부
```
 public ResponseEntity<ChatListResponseDto> getAllChatByGroupId(
	   @Parameter(name = "roomId", description = "특정 채팅방 id", in = ParameterIn.PATH) @PathVariable Long roomId) {
```

# 4. DTO 설정 (여기는 시간이 남으신다면......!)
## **`@Schema`Request Body, Response 각 Schema 정보 명세**
Swagger Schemas 기능을 이용해 request body, response value를 확인 / 입력 할 수 있다.
`request body`를 위한 dto 필드에 `schema`을 사용하면 `swagger`에 예시를 표현할 수 있고, 최하단 `schemas` 섹션을 통해 추가 정보를 제공할 수 있다.
class 상단에 @Schema 어노테이션을 이용해, 해당 클래스가 어떤 클래스인지 설명을 적어줄 수 있다.
- description : 한글명
- defaultValue : 기본값
- allowableValues : 허용되는 값들
```
@Schema(description = "채팅방 조회 응답 DTO")
public class ChatResponseDto {

    @Schema(description = "채팅방 아이디", example = "1")
    private Long roomId;

    @Schema(description = "작성자 아이디", example = "1")
    private Long userId;

    @Schema(description = "작성자")
    private String writer;

    @Schema(description = "메세지 내용")
    private String message;

    @Schema(description = "메세지 생성 일자")
    private LocalDateTime createdAt;
}
```
![728886CF-0EED-48C1-9926-9E28BD035190_4_5005_c](https://github.com/JihyeChu/PetNexus/assets/126750615/7975cc18-6ca8-4c89-8af8-c91de8d173fa)

   
# 📍Authorize 버튼의 필요성 
편리성의 측면에서 가장 이상적인 것은 Swagger UI 페이지의 상단에 Authorize 버튼을 도입하는 방법이다. 이 버튼은 기본적으로 서버로 전송되는 모든 HTTP 요청 메시지들에 특정한 정보를 공통적으로 포함시키는 기능을 제공한다. 로그인을 통해 토큰을 발급 받은 후, 이 버튼을 통해 Authorization 헤더에 토큰을 설정해놓으면, 우리는 로그인에 성공한 사용자의 브라우저 상태를 모방하는 것이 가능해진다.

## Spring Security 인증 적용
대부분의 API 서비스는 인증과 관련된 코드를 포함하기 마련이기 때문에, Swagger-ui에서 API를 테스트하기 위해서 실행할 때에도 인증 정보를 필요로 하게 된다. 

**Header에 JWT 담기**
```
 @Configuration
public class SwaggerConfig {

    @Bean
    public OpenAPI openAPI() {
        Info info = new Info()
            .version("v1.0.0")
            .title("API")
            .description("");

        // SecurityScheme 명
        String jwt = "JWT";
        // API 요청헤더에 인증정보(토큰) 포함
        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
        // SecuritySchemes 등록
        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
            .name(jwt)
            .type(SecurityScheme.Type.HTTP) // HTTP 방식
            .scheme("bearer")
            .bearerFormat("JWT") // 토큰 형식을 지정하는 임의의 문자(Optional)
        );

        return new OpenAPI()
            .info(info)
            .addSecurityItem(securityRequirement)
            .components(components);
    }
}
```
 
![7BB626A0-75B5-45BC-AD95-F13AB99C32CB](https://github.com/JihyeChu/PetNexus/assets/126750615/65f13005-7c60-45d5-ac2d-4e1a20056132)
위와 같이 Security 설정을 마치고 Swagger-ui에 접속하면, 인증을 위한 버튼이 추가된 것을 볼 수 있다.
**Authorize 버튼**이 표시되고 전역 인증 설정을 할 수 있다.
만약 인증 정보를 입력하지 않은 상태에서, 인증이 필요한 API를 실행하면 인증 오류 응답을 받게 된다.
 
 
![6B1366A7-52A3-41F3-8C91-BBE1DB214689](https://github.com/JihyeChu/PetNexus/assets/126750615/d20fcfb8-0aad-4614-a565-e425bf8da238)
추가된 버튼을 클릭하면 인증키를 입력할 수 있는 팝업이 나타나며, 로그인 후 얻은 Bearer 제외한 토큰값 넣어준 후 Authorize 버튼을 눌러서 등록 
→ 모든 API요청에 들어갈 토큰들을 전역적으로 설정해줄 수가 있다.
 
 
![B05F3FFC-D266-458E-AD6F-A2E8EC336AC2](https://github.com/JihyeChu/PetNexus/assets/126750615/84e09fbb-edcf-44c6-8cf3-87bc3a046ab7)
이제 다시 API를 실행해 보면 정상적으로 실행되는 것을 확인할 수 있다. 이때 화면의 'Curl' 부분을 통해서 요청헤더에 인증정보가 포함되어 호출이 된다.

 
# 실행 화면
적용된 UI를 확인하고 싶으면 아래의 경로로 접속하면 된다.
`http://localhost:8080/swagger-ui/index.html`

![92BCAEAE-9AE3-4248-9106-046858030954_1_105_c](https://github.com/JihyeChu/PetNexus/assets/126750615/84dcf35a-c410-45fa-ba6b-f7ed8360f0e1)
 
 
json 형식으로 보고 싶다면 아래의 경로로 접속하면 된다.
`http://localhost:8080/v3/api-docs`
 
![633D65E2-2080-49E7-9905-E79FC9AA8A70_1_105_c](https://github.com/JihyeChu/PetNexus/assets/126750615/9eb77a5a-7680-479a-985c-196f399bfa39)
 
 
![1A2D61E5-C6D7-47A3-9B44-A1BE71AAFC38_1_105_c](https://github.com/JihyeChu/PetNexus/assets/126750615/4242dbd7-ef31-4f4c-87b9-ec1d3d167f2e)
