### PR TITLE
[Feat] Create CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: CI
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # checkout branch create
+    - uses: actions/checkout@v3
+
+      # java use
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '17'
+
+      # application, yml set-up
+    - name: yml 파일 생성
+      run: |
+          touch ./src/main/resources/application.properties
+          echo "${{ secrets.PROPERTIES }}" > ./src/main/resources/application.properties
+          touch ./src/main/resources/application.yml
+          echo "${{ secrets.OAUTH }}" > ./src/main/resources/application.yml
+          
+      # chmod
+    - name: Build with Gradle
+      run: chmod +x gradlew
+      
+      # build Gradle
+    - name: Build with Gradle
+      run: ./gradlew clean build --exclude-task test


### PR DESCRIPTION
## CI/CD란 ?

서비스 기능 개발 이후에는 빌드, 테스트, 소스 병합, 릴리즈, 배포라는 일련의 과정을 거친다. 하지만 이런 작업들은 생각보다 굉장히 번거로운 작업이며 프로젝트 규모가 클수록 괴로움은 증가한다.

CI/CD는 Continuous Integration, Continuous Deliver, Continuous Deployment를 나타내는 용어이며 위 과정들을 자동화하여 불필요한 공수를 줄이고 보다 빠른 서비스 제공을 할 수 있는 효과를 가질 수 있다.

**즉, push를 하게되면 자동으로 빌드 테스트하고!  테스트 코드도 한바뀌 돌리고! 배포 파일 만들고! 배포 서버에 보내준다 이말이다!**

## GITHUB Action

CI/CD 툴은 많다. 대표적으로 “Jenkins” 모르겠고, 깃허브를 통해 바로 쓸수 있는 깃 액션을 쓴다.

## CI->CD

CI와 CD는 어찌 보면 한 몸이다. 그치만 배포를 아직 하지 않았고 dev repo에 코드만 푸시하는 상황이기 때문에
- CI를 진행하고
- dev->main push 할 때 CI/CD 통합하여 바로 배포에 진행 할 예정이다. (우선 CI 먼저해보고 CD 붙이는 걸로^^..)

## CI 빌드 테스트?

- 쉽게 말하자면 github에서 깡통 서버를 띄운다?
- 실행가능한 상태로 만들어 준 뒤에
- 빌드도 해보고, 테스트 코드도 돌려보는 것 그게 CI 작동이다.

## CI 파일 생성 과정 
1. Git PR옆에 action 을 누르게 되면 깡통 부터 만들 수도 있고, 기본 툴들을 제공해준다.
2. Java with Gradle 을 선택하여 ci빌드 문서를 작성하겠다. (배포는 아직이고 gradle을 사용하니까)
3. GitHub Actions에서 가장 상위 개념인 워크플로우(workflows)폴더에서 자동화해놓은 작업 과정 파일들이 .yml 확장자로 저장된다.

## .yml

```
name: CI

# 1. on을 통해서 github action이 언제 실행 되어 지는지 설정 한다.
on:
  push:
    branches: [ "dev" ]
  pull_request:
    branches: [ "dev" ]

permissions:
  contents: write

# jobs란 실행하는 작업의 제일 큰 단위, 여러개일수도 있지만 최소한 1개이상이며, job끼리 서로 정보를 교환할 수도 있다.
# 2. jobs bulid를 통해 실행 환경을 먼저 run-on 시켜준다.(필수) // ubuntu환경을 많이 쓴다더라 카더라..
jobs:
  build:
    runs-on: ubuntu-latest

    # 3. jobs에선 단계(step)를 설정할 수 있다. 
    steps:

      # 4. 해당 레포지토리를 pull 받고 이동하는 action 대부분의 workflow에서 사용
      # 누가 만들어 놓은 Action을 사용할 때에는 uses 키워드를 사용한다.
    - uses: actions/checkout@v3

      # 5. 프로그래밍 언어가 설치되어 있지 않기 때문에 프로젝트 실행에 필요한 언어들을 action을 통해 다운
    - uses: actions/setup-java@v3
      with:
        distribution: 'zulu'
        java-version: '17'

      # 6. application, yml set-up
    - name: yml 파일 생성
      run: |
          touch ./src/main/resources/application.properties
          echo "${{ secrets.PROPERTIES }}" > ./src/main/resources/application.properties
          touch ./src/main/resources/application.yml
          echo "${{ secrets.OAUTH }}" > ./src/main/resources/application.yml
          
      # 7. chmod Build를 할수 있는 권한을 준다.
      # 커맨드나 스크립트를 실행할 때는 run 키워드를 사용한다.
    - name: Build with Gradle
      run: chmod +x gradlew
      
      # 8. 빌드 테스트 진행.
    - name: Build with Gradle
      run: ./gradlew clean build --exclude-task test
```

## Action?

근데 왜? 액션인가?
위의 코드를 보면 알겟지만 use 즉, 액션을 사용한다.
Github에서의 액션은 누군가 만들어놓은 라이브러리 중 하나로 보면 쉬울 것같다.
풀을 당겨오는 로직도 누군가 만들어오는 액션을 사용하고,
자바설치도, 
이런것도 가능하다.
성공한다면 메세지를 보내준다거나, 실패한다면 실패 오류코드를 보여준다거나, 혹은 실패시 슬랙에도 알람을 보내줄수도있다.
깃 액션을 통해서 여러가지 사용할수 있지만 안해~

