### PR TITLE
[Refactor] trade - price 금액 표시 방법 수정

### DIFF
--- a/src/main/java/com/sparta/petnexus/trade/dto/TradeResponseDto.java
+++ b/src/main/java/com/sparta/petnexus/trade/dto/TradeResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.text.DecimalFormat;
 import java.util.List;
 
 @Builder
@@ -31,7 +32,7 @@ public class TradeResponseDto {
     @Schema(description = "trade 경도")
     private String longitude;
     @Schema(description = "trade 가격")
-    private int price;
+    private String price;
     @Schema(description = "trade 품목")
     private String category;
     @Schema(description = "trade 좋아요 수")
@@ -47,6 +48,8 @@ public class TradeResponseDto {
 
 
     public static TradeResponseDto of(Trade trade) {
+        DecimalFormat df = new DecimalFormat("###,###,###");
+
         return TradeResponseDto.builder()
                 .id(trade.getId())
                 .title(trade.getTitle())
@@ -54,7 +57,7 @@ public class TradeResponseDto {
                 .username(trade.getUser().getUsername())
                 .latitude(trade.getLatitude())
                 .longitude(trade.getLongitude())
-                .price(trade.getPrice())
+                .price(df.format(trade.getPrice()))
                 .category(String.valueOf(trade.getCategory()))
                 .tradeLikeCount(trade.getTradeLikes().size())
                 .tradeBookmarkList(trade.getTradeBookmarks().stream().map(bookmark -> bookmark.getTrade().getTitle()).toList())


### PR DESCRIPTION
### 개선 사항
중고장터의 금액 표시 변경(5000 -> 5,000)

### 표시 양식 
###,###,###
ex) 123,456,789

### 추가
DecimalFormat 을 통해 price를 위 형식 + String  으로 TradeResponseDto 에서만 내보냅니다.
* Entity, TradeRequestDto의 price는 int 입니다.
*  DecimalFormat 으로 변환한 결과는 기본적으로 문자열 형태로 반환됩니다.
![image](https://github.com/JihyeChu/PetNexus/assets/114731015/6c16fa95-632c-4364-a255-e80a3030745d)
